### PR TITLE
[UI] Add breadcrumb navigation on Hashing algorithm selection and mov…

### DIFF
--- a/src/EM.Hasher/EM.Hasher.csproj
+++ b/src/EM.Hasher/EM.Hasher.csproj
@@ -45,6 +45,9 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
+    <None Update="Views\HashingAlgorithms.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </None>
     <Page Update="Controls\Ported\CopyButton.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/src/EM.Hasher/Services/Navigation/NavigationService.cs
+++ b/src/EM.Hasher/Services/Navigation/NavigationService.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * EM Hasher
- * Copyright © 2025 Enda Mullally (em.apps@outlook.ie)
+ * Copyright © 2025-2026 Enda Mullally (em.apps@outlook.ie)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@
 
 using System;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Animation;
 
 namespace EM.Hasher.Services.Navigation;
 
@@ -29,12 +30,22 @@ public class NavigationService : INavigationService
 
     public void Navigate(Type viewType, object? parameter = null)
     {
-        _frame?.Navigate(viewType, parameter);
+        var transitionInfo = new SlideNavigationTransitionInfo
+        {
+            Effect = SlideNavigationTransitionEffect.FromRight
+        };
+
+        _frame?.Navigate(viewType, parameter, transitionInfo);
     }
 
     public void Navigate<TView>(object? parameter = null)
     {
-        _frame?.Navigate(typeof(TView), parameter);
+        var transitionInfo = new SlideNavigationTransitionInfo
+        {
+            Effect = SlideNavigationTransitionEffect.FromRight
+        };
+
+        _frame?.Navigate(typeof(TView), parameter, transitionInfo);
     }
 
     public void GoBack()

--- a/src/EM.Hasher/ViewModels/SettingsViewModel.cs
+++ b/src/EM.Hasher/ViewModels/SettingsViewModel.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * EM Hasher
- * Copyright © 2025 Enda Mullally (em.apps@outlook.ie)
+ * Copyright © 2025-2026 Enda Mullally (em.apps@outlook.ie)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
@@ -38,6 +39,7 @@ public partial class SettingsViewModel : ObservableObject
     private readonly WindowEx _currentWindow = null!;
     private readonly Dictionary<string, bool> _hashAlgorithmsEnabled = [];
     private readonly bool _initialized = false;
+    private readonly ObservableCollection<string> _breadcrumbItems = ["Settings", "Hashing Algorithms"];
 
     [ObservableProperty]
     public partial string? VersionDescription
@@ -88,6 +90,8 @@ public partial class SettingsViewModel : ObservableObject
     public bool IsAlgorithmSelectionInvalid => !IsCrc32Enabled && !IsMd5Enabled && !IsSha256Enabled && !IsSha512Enabled;
 
     public bool IsTrialMode => _settingsProvider.IsTrialMode;
+
+    public ObservableCollection<string> BreadcrumbItems => _breadcrumbItems;
 
     public SettingsViewModel(
         ICachedStoreAppLicense cachedStoreAppLicenseModel,

--- a/src/EM.Hasher/Views/HashingAlgorithms.xaml
+++ b/src/EM.Hasher/Views/HashingAlgorithms.xaml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Page
+    x:Class="EM.Hasher.Views.HashingAlgorithms"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:EM.Hasher.Views"
+    xmlns:localConverters="using:EM.Hasher.Converters"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:sys="using:System"
+    xmlns:toolkitConverters="using:CommunityToolkit.WinUI.Converters"
+    xmlns:ui="using:CommunityToolkit.WinUI"
+    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    NavigationCacheMode="Required"
+    mc:Ignorable="d">
+    <Page.Resources>
+        <toolkitConverters:BoolToVisibilityConverter x:Key="BoolToVisibility" />
+        <toolkitConverters:BoolNegationConverter x:Key="BoolNegation" />
+        <localConverters:FontSizeReductionConverter x:Key="FontSizeReducer" />
+
+        <x:Double x:Key="SettingsCardSpacing">4</x:Double>
+
+        <Style
+            x:Key="SettingsSectionHeaderTextBlockStyle"
+            BasedOn="{StaticResource BodyStrongTextBlockStyle}"
+            TargetType="TextBlock">
+            <Style.Setters>
+                <Setter Property="Margin" Value="5,10" />
+            </Style.Setters>
+        </Style>
+
+        <Style
+            x:Key="BreadcrumbTextBlockStyle"
+            BasedOn="{StaticResource BodyStrongTextBlockStyle}"
+            TargetType="TextBlock">
+            <Style.Setters>
+                <Setter Property="Margin" Value="3,7" />
+            </Style.Setters>
+        </Style>
+
+        <Style
+            x:Key="CompactSettingsCardStyle"
+            TargetType="controls:SettingsCard">
+            <Style.Setters>
+                <Setter Property="MinHeight" Value="40" />
+                <Setter Property="Padding" Value="16,8" />
+            </Style.Setters>
+        </Style>
+    </Page.Resources>
+    <ScrollViewer>
+        <Grid>
+            <StackPanel HorizontalAlignment="Stretch" Spacing="{StaticResource SettingsCardSpacing}">
+
+                <BreadcrumbBar
+                    x:Name="uxBreadcrumbBar"
+                    ItemClicked="OnBreadcrumbBarItemClicked"
+                    ItemsSource="{x:Bind ViewModel.BreadcrumbItems, Mode=OneWay}">
+                    <BreadcrumbBar.ItemTemplate>
+                        <DataTemplate x:DataType="x:String">
+                            <TextBlock Style="{StaticResource BreadcrumbTextBlockStyle}" Text="{x:Bind}" />
+                        </DataTemplate>
+                    </BreadcrumbBar.ItemTemplate>
+                </BreadcrumbBar>
+
+                <controls:SettingsCard Header="CRC-32" Style="{StaticResource CompactSettingsCardStyle}">
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.IsCrc32Enabled, Mode=TwoWay}" />
+                </controls:SettingsCard>
+
+                <controls:SettingsCard Header="MD5" Style="{StaticResource CompactSettingsCardStyle}">
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.IsMd5Enabled, Mode=TwoWay}" />
+                </controls:SettingsCard>
+
+                <controls:SettingsCard Style="{StaticResource CompactSettingsCardStyle}">
+                    <controls:SettingsCard.Header>
+                        <Grid VerticalAlignment="Center">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="70" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock
+                                x:Name="sha256HeaderTextBlock"
+                                Grid.Column="0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                Text="SHA-256" />
+                            <TextBlock
+                                Grid.Column="1"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                FontSize="{Binding ElementName=sha256HeaderTextBlock, Path=FontSize, Converter={StaticResource FontSizeReducer}, ConverterParameter='-3'}"
+                                Foreground="{ThemeResource TextFillColorTertiary}"
+                                Text="(Not available in trial version)"
+                                Visibility="{x:Bind ViewModel.IsTrialMode, Converter={StaticResource BoolToVisibility}, Mode=OneWay}" />
+                        </Grid>
+                    </controls:SettingsCard.Header>
+
+                    <ToggleSwitch IsEnabled="{x:Bind ViewModel.IsTrialMode, Converter={StaticResource BoolNegation}, Mode=OneWay}" IsOn="{x:Bind ViewModel.IsSha256Enabled, Mode=TwoWay}" />
+                </controls:SettingsCard>
+
+                <controls:SettingsCard Style="{StaticResource CompactSettingsCardStyle}">
+                    <controls:SettingsCard.Header>
+                        <Grid VerticalAlignment="Center">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="70" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock
+                                x:Name="sha512HeaderTextBlock"
+                                Grid.Column="0"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                Text="SHA-512" />
+                            <TextBlock
+                                Grid.Column="1"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                FontSize="{Binding ElementName=sha512HeaderTextBlock, Path=FontSize, Converter={StaticResource FontSizeReducer}, ConverterParameter='-3'}"
+                                Foreground="{ThemeResource TextFillColorTertiary}"
+                                Text="(Not available in trial version)"
+                                Visibility="{x:Bind ViewModel.IsTrialMode, Converter={StaticResource BoolToVisibility}, Mode=OneWay}" />
+                        </Grid>
+                    </controls:SettingsCard.Header>
+
+                    <ToggleSwitch IsEnabled="{x:Bind ViewModel.IsTrialMode, Converter={StaticResource BoolNegation}, Mode=OneWay}" IsOn="{x:Bind ViewModel.IsSha512Enabled, Mode=TwoWay}" />
+                </controls:SettingsCard>
+
+                <controls:SettingsCard Visibility="{x:Bind ViewModel.IsAlgorithmSelectionInvalid, Converter={StaticResource BoolToVisibility}, Mode=OneWay}">
+                    <controls:SettingsCard.Description>
+                        <TextBlock Foreground="PaleVioletRed" Text="Please select at least one hash algorithm" />
+                    </controls:SettingsCard.Description>
+                </controls:SettingsCard>
+            </StackPanel>
+        </Grid>
+    </ScrollViewer>
+</Page>

--- a/src/EM.Hasher/Views/HashingAlgorithms.xaml.cs
+++ b/src/EM.Hasher/Views/HashingAlgorithms.xaml.cs
@@ -1,6 +1,6 @@
 /*
  * EM Hasher
- * Copyright © 2025-2026 Enda Mullally (em.apps@outlook.ie)
+ * Copyright Â© 2025 Enda Mullally (em.apps@outlook.ie)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,23 +22,31 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace EM.Hasher.Views;
 
-public sealed partial class Settings : Page
+public sealed partial class HashingAlgorithms : Page
 {
     public SettingsViewModel ViewModel
     {
         get;
     }
 
-    public Settings()
+    public HashingAlgorithms()
     {
         ViewModel = App.GetService<SettingsViewModel>();
 
         InitializeComponent();
     }
 
-    private void OnHashingAlgorithmsCardTapped(object sender, Microsoft.UI.Xaml.Input.TappedRoutedEventArgs e)
+    private void OnBreadcrumbBarItemClicked(BreadcrumbBar sender, BreadcrumbBarItemClickedEventArgs args)
     {
-        var navigationService = App.GetService<INavigationService>();
-        navigationService.Navigate<HashingAlgorithms>();
+        if (args.Index == 0)
+        {
+            // Only allow navigating back if the algorithm selection is valid.
+            if (!ViewModel.IsAlgorithmSelectionInvalid)
+            {
+                var navigationService = App.GetService<INavigationService>();
+
+                navigationService.GoBack();
+            }
+        }
     }
 }

--- a/src/EM.Hasher/Views/Settings.xaml
+++ b/src/EM.Hasher/Views/Settings.xaml
@@ -48,85 +48,13 @@
 
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Settings" />
 
-                <controls:SettingsExpander
+                <controls:SettingsCard
+                    x:Name="uxHashingAlgorithmsCard"
                     Description="Select your preferred hasing algorithms"
                     Header="Hashing Algorithms"
                     HeaderIcon="{ui:FontIcon Glyph=&#xE8EF;}"
-                    IsExpanded="True">
-                    <controls:SettingsExpander.Items>
-
-                        <controls:SettingsCard Header="CRC-32">
-                            <ToggleSwitch IsOn="{x:Bind ViewModel.IsCrc32Enabled, Mode=TwoWay}" />
-                        </controls:SettingsCard>
-
-                        <controls:SettingsCard Header="MD5">
-                            <ToggleSwitch IsOn="{x:Bind ViewModel.IsMd5Enabled, Mode=TwoWay}" />
-                        </controls:SettingsCard>
-
-                        <controls:SettingsCard>
-                            <controls:SettingsCard.Header>
-                                <Grid VerticalAlignment="Center">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="70" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-
-                                    <TextBlock
-                                        x:Name="sha256HeaderTextBlock"
-                                        Grid.Column="0"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center"
-                                        Text="SHA-256" />
-                                    <TextBlock
-                                        Grid.Column="1"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center"
-                                        FontSize="{Binding ElementName=sha256HeaderTextBlock, Path=FontSize, Converter={StaticResource FontSizeReducer}, ConverterParameter='-3'}"
-                                        Foreground="{ThemeResource TextFillColorTertiary}"
-                                        Text="(Not available in trial version)"
-                                        Visibility="{x:Bind ViewModel.IsTrialMode, Converter={StaticResource BoolToVisibility}, Mode=OneWay}" />
-                                </Grid>
-                            </controls:SettingsCard.Header>
-
-                            <ToggleSwitch IsEnabled="{x:Bind ViewModel.IsTrialMode, Converter={StaticResource BoolNegation}, Mode=OneWay}" IsOn="{x:Bind ViewModel.IsSha256Enabled, Mode=TwoWay}" />
-                        </controls:SettingsCard>
-
-                        <controls:SettingsCard>
-                            <controls:SettingsCard.Header>
-                                <Grid VerticalAlignment="Center">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="70" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-
-                                    <TextBlock
-                                        x:Name="sha512HeaderTextBlock"
-                                        Grid.Column="0"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center"
-                                        Text="SHA-512" />
-                                    <TextBlock
-                                        Grid.Column="1"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center"
-                                        FontSize="{Binding ElementName=sha512HeaderTextBlock, Path=FontSize, Converter={StaticResource FontSizeReducer}, ConverterParameter='-3'}"
-                                        Foreground="{ThemeResource TextFillColorTertiary}"
-                                        Text="(Not available in trial version)"
-                                        Visibility="{x:Bind ViewModel.IsTrialMode, Converter={StaticResource BoolToVisibility}, Mode=OneWay}" />
-                                </Grid>
-                            </controls:SettingsCard.Header>
-
-                            <ToggleSwitch IsEnabled="{x:Bind ViewModel.IsTrialMode, Converter={StaticResource BoolNegation}, Mode=OneWay}" IsOn="{x:Bind ViewModel.IsSha512Enabled, Mode=TwoWay}" />
-                        </controls:SettingsCard>
-
-                        <controls:SettingsCard Visibility="{x:Bind ViewModel.IsAlgorithmSelectionInvalid, Converter={StaticResource BoolToVisibility}, Mode=OneWay}">
-                            <controls:SettingsCard.Description>
-                                <TextBlock Foreground="PaleVioletRed" Text="Please select at least one hash algorithm" />
-                            </controls:SettingsCard.Description>
-                        </controls:SettingsCard>
-
-                    </controls:SettingsExpander.Items>
-                </controls:SettingsExpander>
+                    IsClickEnabled="True"
+                    Tapped="OnHashingAlgorithmsCardTapped" />
 
                 <TextBlock Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" Text="Preferences" />
 


### PR DESCRIPTION
[UI] Add breadcrumb navigation on Settings->Hash Algorithm selection and move the hash algorithm toggle switchs to their own view. This will enable adding more algorithms soon!

<img width="914" height="822" alt="image" src="https://github.com/user-attachments/assets/e479dca3-6e45-4d73-8f71-a6aefc632e64" />

<img width="914" height="822" alt="image" src="https://github.com/user-attachments/assets/254ec278-f550-404b-bd84-dfd087ba3c2e" />
