### PR TITLE
Dropping back to WinAppSDK 1.8 to resolve an issue with bloated .msix…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Show installed Windows App SDK Runtime version
       if: (github.ref == 'refs/heads/main' || inputs.fullbuild)
       run: |
-        Get-AppxPackage -Name "Microsoft.WindowsAppRuntime.2*" | Where-Object { $_.Architecture -eq "x64" }
+        Get-AppxPackage -Name "Microsoft.WindowsAppRuntime.*" | Where-Object { $_.Architecture -eq "x64" }
         
     - name: Register the EM.Hasher.Tests Appx
       if: (github.ref == 'refs/heads/main' || inputs.fullbuild)

--- a/src/EM.Hasher (Package)/EM.Hasher (Package).wapproj
+++ b/src/EM.Hasher (Package)/EM.Hasher (Package).wapproj
@@ -102,7 +102,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260508005" />
   </ItemGroup>
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.targets" />
 </Project>

--- a/src/EM.Hasher.Tests/EM.Hasher.Tests.csproj
+++ b/src/EM.Hasher.Tests/EM.Hasher.Tests.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="18.5.1" />  
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260508005" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
   </ItemGroup>

--- a/src/EM.Hasher/EM.Hasher.csproj
+++ b/src/EM.Hasher/EM.Hasher.csproj
@@ -36,7 +36,7 @@
 	<PackageReference Include="Humanizer.Core" Version="3.0.10" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.260508005" />
     <PackageReference Include="System.Diagnostics.EventLog" Version="10.0.8" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.8" />
     <PackageReference Include="WinUIEx" Version="2.9.0" />


### PR DESCRIPTION
Dropping back to WinAppSDK 1.8 to resolve an issue with bloated .msixupload/.appx packages (onnxruntime.dll)