### PR TITLE
Package version fix

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -61,7 +61,8 @@ jobs:
             /p:PackageCertificateThumbprint= `
             /p:PackageCertificateKeyFile= `
             /p:Version="${{ steps.version.outputs.version }}" `
-            /p:FileVersion="${{ steps.version.outputs.version }}"
+            /p:FileVersion="${{ steps.version.outputs.version }}" `
+            /p:Copyright="Copyright © 2025-2026 Enda Mullally"
 
       - name: Upload package bundle (.msixupload)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -60,8 +60,8 @@ jobs:
             /p:GenerateTemporaryStoreCertificate=false `
             /p:PackageCertificateThumbprint= `
             /p:PackageCertificateKeyFile= `
-            /p:Version=${{ steps.version.outputs.version }}" `
-            /p:FileVersion=${{ steps.version.outputs.version }}"
+            /p:Version="${{ steps.version.outputs.version }}" `
+            /p:FileVersion="${{ steps.version.outputs.version }}"
 
       - name: Upload package bundle (.msixupload)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -24,6 +24,18 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Read app manifest version
+        working-directory: "src\\EM.Hasher (Package)"
+        id: version
+        shell: pwsh
+        run: |
+          [xml]$manifest = Get-Content "Package.appxmanifest"
+          $version = $manifest.Package.Identity.Version -replace '\.0$'
+          "version=$version" >> $env:GITHUB_OUTPUT
+
+      - name: Display app manifest version
+        run: echo "App manifest version is ${{ steps.version.outputs.version }}"
+
       - name: Restore EM Hasher package project
         working-directory: "src\\EM.Hasher (Package)"
         run: |
@@ -48,6 +60,8 @@ jobs:
             /p:GenerateTemporaryStoreCertificate=false `
             /p:PackageCertificateThumbprint= `
             /p:PackageCertificateKeyFile= `
+            /p:Version=${{ steps.version.outputs.version }}" `
+            /p:FileVersion=${{ steps.version.outputs.version }}"
 
       - name: Upload package bundle (.msixupload)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -62,7 +62,7 @@ jobs:
             /p:PackageCertificateKeyFile= `
             /p:Version="${{ steps.version.outputs.version }}" `
             /p:FileVersion="${{ steps.version.outputs.version }}" `
-            /p:Copyright="Copyright © 2025-2026 Enda Mullally"
+            /p:Copyright="© 2025-2026 Enda Mullally"
 
       - name: Upload package bundle (.msixupload)
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Ensure the version & product version properties are written to the EM.Hasher.exe manifest correctly. Also add the copyright property. Let's see if this improves the winget version reasoning.

<img width="405" height="660" alt="image" src="https://github.com/user-attachments/assets/9b3993aa-bd8d-476f-945c-f16c5ecca98a" />
