### PR TITLE
Authenticode UI blocker

### DIFF
--- a/src/EM.Hasher (Package)/Package.appxmanifest
+++ b/src/EM.Hasher (Package)/Package.appxmanifest
@@ -15,7 +15,7 @@
   <Identity
     Name="26772EndaMullally.EMHasher"
     Publisher="CN=3828CB90-B2F7-46C6-8B9B-6DDEBE9CBF4F"
-    Version="1.3.79.0" />
+    Version="1.3.80.0" />
   
   <!-- Above is [Major].[Minor].[Build].[Revision]  -->
   <!-- Will display in app as v[Major].[Minor] Build([Build]) i.e "v1.1 (Build 28)" -->

--- a/src/EM.Hasher/Controls/FileAuthenticodeInformationControl.xaml
+++ b/src/EM.Hasher/Controls/FileAuthenticodeInformationControl.xaml
@@ -28,14 +28,52 @@
             Glyph="&#xEB95;" />
 
         <!--
-            Details Grid with aligned rows
-            TODO: Fix hardcoded column width (80) below and use element binding|converter to identify the widest "Auto" column in the grid
+            Loading grid
+        -->
+
+        <Grid
+            Grid.Column="1"
+            Margin="0,0,0,0"
+            Visibility="{x:Bind IsLoading, Converter={StaticResource BoolToVisibility}, Mode=OneWay}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <!--  Row 0: Loading  -->
+            <TextBlock
+                Grid.Row="0"
+                Grid.Column="0"
+                Margin="0,0,20,3"
+                Text="Loading digital signature details..."
+                TextWrapping="Wrap" />
+
+            <!--  Row 1: ProgressBar  -->
+            <ProgressBar
+                Grid.Row="1"
+                Grid.Column="0"
+                Width="200"
+                Margin="0,10,0,0"
+                HorizontalAlignment="Left"
+                IsIndeterminate="True"
+                Maximum="100"
+                Minimum="0"
+                ShowError="False"
+                ShowPaused="False" />
+        </Grid>
+
+        <!--
+            Details grid with aligned rows
         -->
 
         <Grid
             Grid.Column="1"
             Grid.ColumnSpan="2"
-            Margin="0,0,0,0">
+            Margin="0,0,0,0"
+            Visibility="{x:Bind IsLoading, Converter={StaticResource BoolToVisibility}, ConverterParameter=True, Mode=OneWay}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />

--- a/src/EM.Hasher/Controls/FileAuthenticodeInformationControl.xaml.cs
+++ b/src/EM.Hasher/Controls/FileAuthenticodeInformationControl.xaml.cs
@@ -28,6 +28,15 @@ public sealed partial class FileAuthenticodeInformationControl : UserControl
         InitializeComponent();
     }
 
+    public bool IsLoading
+    {
+        get => (bool)GetValue(IsLoadingProperty);
+        set => SetValue(IsLoadingProperty, value);
+    }
+
+    public static readonly DependencyProperty IsLoadingProperty =
+        DependencyProperty.Register(nameof(IsLoading), typeof(bool), typeof(FileAuthenticodeInformationControl), new PropertyMetadata(false));
+
     public string Signer
     {
         get => (string)GetValue(SignerProperty);

--- a/src/EM.Hasher/ViewModels/CalculateViewModel.cs
+++ b/src/EM.Hasher/ViewModels/CalculateViewModel.cs
@@ -78,6 +78,9 @@ public partial class CalculateViewModel : ObservableObject, INavigationAware
     public partial string? FileProductVersion { get; private set; } = string.Empty;
 
     [ObservableProperty]
+    public partial bool IsLoadingAuthenticodeInfo { get; private set; } = false;
+
+    [ObservableProperty]
     public partial bool HasFileProductVersion { get; private set; } = false;
 
     [ObservableProperty]
@@ -137,6 +140,9 @@ public partial class CalculateViewModel : ObservableObject, INavigationAware
                     HasFileProductVersion = !string.IsNullOrWhiteSpace(FileProductVersion);
                 }
 
+                // Setting IsSigned here to true to ensure the authenticode loading grid is visible
+                // if the previously selected file was not signed.
+                IsLoadingAuthenticodeInfo = IsSigned = true;
                 var signingInfo = await _authenticodeInfoProvider.GetAuthenticodeInfoAsync(_selectedFileName);
                 if (signingInfo != null)
                 {
@@ -145,7 +151,8 @@ public partial class CalculateViewModel : ObservableObject, INavigationAware
                     Issuer = signingInfo.Issuer;
                     IsTimeStamped = signingInfo.IsTimeStamped;
                     SigningTime = signingInfo.SigningTime;
-                }
+                }                
+                IsLoadingAuthenticodeInfo = false;
 
                 // A new file is selected, so force recalculation. Fire the hash
                 // fan-out last, once the metadata above has rendered.

--- a/src/EM.Hasher/Views/Calculate.xaml
+++ b/src/EM.Hasher/Views/Calculate.xaml
@@ -110,6 +110,7 @@
                 Visibility="{x:Bind ViewModel.IsSigned, Converter={StaticResource BoolToVisibility}, Mode=OneWay}">
                 <controls:SettingsCard.Header>
                     <localcontrols:FileAuthenticodeInformationControl
+                        IsLoading="{x:Bind ViewModel.IsLoadingAuthenticodeInfo, Mode=OneWay}"
                         IsTimeStamped="{x:Bind ViewModel.IsTimeStamped, Mode=OneWay}"
                         Issuer="{x:Bind ViewModel.Issuer, Mode=OneWay}"
                         Signer="{x:Bind ViewModel.Signer, Mode=OneWay}"


### PR DESCRIPTION
I've noticed the UI blocking while loading authenticode info for large signed files (usually anything > 1GB).

Add authenticode loading state (UI) which will be displayed in such cases.

<img width="884" height="792" alt="image" src="https://github.com/user-attachments/assets/6d230f47-e3ae-46f4-94ee-1c9a8fe0435d" />

<img width="884" height="792" alt="image" src="https://github.com/user-attachments/assets/b8702e4c-c494-41b9-bb6e-b0326d62b189" />

