### PR TITLE
Show loading UI (state) when loading file details...

### DIFF
--- a/src/EM.Hasher/Controls/FileInformationControl.xaml
+++ b/src/EM.Hasher/Controls/FileInformationControl.xaml
@@ -29,14 +29,52 @@
             Glyph="&#xE946;" />
 
         <!--
+            Loading grid
+        -->
+
+        <Grid
+            Grid.Column="1"
+            Margin="0,0,0,0"
+            Visibility="{x:Bind IsLoading, Converter={StaticResource BoolToVisibility}, Mode=OneWay}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <!--  Row 0: Loading  -->
+            <TextBlock
+                Grid.Row="0"
+                Grid.Column="0"
+                Margin="0,0,20,3"
+                Text="{x:Bind LoadingText, Mode=OneWay}"
+                TextWrapping="Wrap" />
+
+            <!--  Row 1: ProgressBar  -->
+            <ProgressBar
+                Grid.Row="1"
+                Grid.Column="0"
+                Width="200"
+                Margin="0,10,0,0"
+                HorizontalAlignment="Left"
+                IsIndeterminate="True"
+                Maximum="100"
+                Minimum="0"
+                ShowError="False"
+                ShowPaused="False" />
+        </Grid>
+
+        <!--
             Details Grid with aligned rows
-            TODO: Fix hardcoded column width (80) below and use element binding|converter to identify the widest "Auto" column in the grid
         -->
 
         <Grid
             Grid.Column="1"
             Grid.ColumnSpan="2"
-            Margin="0,0,0,0">
+            Margin="0,0,0,0"
+            Visibility="{x:Bind IsLoading, Converter={StaticResource BoolToVisibility}, ConverterParameter=True, Mode=OneWay}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />

--- a/src/EM.Hasher/Controls/FileInformationControl.xaml.cs
+++ b/src/EM.Hasher/Controls/FileInformationControl.xaml.cs
@@ -1,6 +1,6 @@
 /*
  * EM Hasher
- * Copyright © 2025 Enda Mullally (em.apps@outlook.ie)
+ * Copyright © 2025-2026 Enda Mullally (em.apps@outlook.ie)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,6 +27,24 @@ public sealed partial class FileInformationControl : UserControl
     {
         InitializeComponent();
     }
+
+    public bool IsLoading
+    {
+        get => (bool)GetValue(IsLoadingProperty);
+        set => SetValue(IsLoadingProperty, value);
+    }
+
+    public static readonly DependencyProperty IsLoadingProperty =
+        DependencyProperty.Register(nameof(IsLoading), typeof(bool), typeof(FileAuthenticodeInformationControl), new PropertyMetadata(false));
+
+    public string LoadingText
+    {
+        get => (string)GetValue(LoadingTextProperty);
+        set => SetValue(LoadingTextProperty, value);
+    }
+
+    public static readonly DependencyProperty LoadingTextProperty =
+        DependencyProperty.Register(nameof(LoadingText), typeof(string), typeof(FileAuthenticodeInformationControl), new PropertyMetadata(""));
 
     public string FileName
     {

--- a/src/EM.Hasher/Strings/en-us/Resources.resw
+++ b/src/EM.Hasher/Strings/en-us/Resources.resw
@@ -129,6 +129,9 @@
   <data name="LoadingAuthenticodeDetails" xml:space="preserve">
     <value>Loading digital signature details...</value>
   </data>
+  <data name="LoadingFileDetails" xml:space="preserve">
+    <value>Loading file details...</value>
+  </data>
   <data name="Product" xml:space="preserve">
     <value>Product</value>
   </data>

--- a/src/EM.Hasher/ViewModels/CalculateViewModel.cs
+++ b/src/EM.Hasher/ViewModels/CalculateViewModel.cs
@@ -163,8 +163,8 @@ public partial class CalculateViewModel : ObservableObject, INavigationAware
     {
         FileLoadingText = loadingText;
 
-        // Setting IsSigned here to true to false to deliberately hide the
-        // autheticode laoding ui while we are loading the file info details.
+        // Setting IsSigned here to false to deliberately hide the
+        // autheticode laoding ui while we are loading file info details.
         IsSigned = false;
         IsLoadingFileInfo = true;
     }

--- a/src/EM.Hasher/ViewModels/CalculateViewModel.cs
+++ b/src/EM.Hasher/ViewModels/CalculateViewModel.cs
@@ -58,6 +58,12 @@ public partial class CalculateViewModel : ObservableObject, INavigationAware
     }
 
     [ObservableProperty]
+    public partial bool IsLoadingFileInfo { get; private set; } = false;
+
+    [ObservableProperty]
+    public partial string FileLoadingText { get; private set; } = string.Empty;
+
+    [ObservableProperty]
     public partial string? FileName { get; private set; } = string.Empty;
 
     [ObservableProperty]
@@ -153,9 +159,24 @@ public partial class CalculateViewModel : ObservableObject, INavigationAware
             new SetAppSubTitleMessage(appSubTitle));
     }
 
+    private void SetFileLoadingState(string loadingText)
+    {
+        FileLoadingText = loadingText;
+
+        // Setting IsSigned here to true to false to deliberately hide the
+        // autheticode laoding ui while we are loading the file info details.
+        IsSigned = false;
+        IsLoadingFileInfo = true;
+    }
+
     private async Task LoadFileInfoAsync()
     {
+        SetFileLoadingState(ResourceExtensions.GetLocalized("LoadingFileDetails"));
+
         var fileDetailsModel = await _fileDetailsProvider.GetFileDetailsAsync(_selectedFileName);
+
+        IsLoadingFileInfo = false; // Hide to loading state (File Details)
+
         if (fileDetailsModel != null)
         {
             UpdateAppSubTitle($"[{fileDetailsModel.FileName}]");
@@ -189,7 +210,7 @@ public partial class CalculateViewModel : ObservableObject, INavigationAware
 
         var signingInfo = await _authenticodeInfoProvider.GetAuthenticodeInfoAsync(_selectedFileName);
 
-        IsLoadingAuthenticodeInfo = false; // Hide to loading state
+        IsLoadingAuthenticodeInfo = false; // Hide to loading state (Authenticode Info)
 
         if (signingInfo != null)
         {

--- a/src/EM.Hasher/Views/Calculate.xaml
+++ b/src/EM.Hasher/Views/Calculate.xaml
@@ -80,7 +80,9 @@
                         FileSize="{x:Bind ViewModel.FileSize, Mode=OneWay}"
                         FileVersion="{x:Bind ViewModel.FileVersion, Mode=OneWay}"
                         HasFileProductVersion="{x:Bind ViewModel.HasFileProductVersion, Mode=OneWay}"
-                        HasFileVersion="{x:Bind ViewModel.HasFileVersion, Mode=OneWay}" />
+                        HasFileVersion="{x:Bind ViewModel.HasFileVersion, Mode=OneWay}"
+                        IsLoading="{x:Bind ViewModel.IsLoadingFileInfo, Mode=OneWay}"
+                        LoadingText="{x:Bind ViewModel.FileLoadingText, Mode=OneWay}" />
                 </controls:SettingsCard.Header>
                 <localcontrols:HandHoverGrid>
                     <localcontrols:IconButton
@@ -89,6 +91,7 @@
                         HorizontalAlignment="Right"
                         VerticalAlignment="Top"
                         Command="{x:Bind ViewModel.OpenFileLocationCommand, Mode=OneWay}"
+                        Visibility="{x:Bind ViewModel.IsLoadingFileInfo, Converter={StaticResource BoolToVisibility}, ConverterParameter=True, Mode=OneWay}"
                         ToolTipService.ToolTip="Open file location">
                         <localcontrols:IconButton.Icon>
                             <FontIcon Glyph="&#xE8E5;" />
@@ -111,9 +114,9 @@
                 <controls:SettingsCard.Header>
                     <localcontrols:FileAuthenticodeInformationControl
                         IsLoading="{x:Bind ViewModel.IsLoadingAuthenticodeInfo, Mode=OneWay}"
-                        LoadingText="{x:Bind ViewModel.AuthenticodeLoadingText, Mode=OneWay}"
                         IsTimeStamped="{x:Bind ViewModel.IsTimeStamped, Mode=OneWay}"
                         Issuer="{x:Bind ViewModel.Issuer, Mode=OneWay}"
+                        LoadingText="{x:Bind ViewModel.AuthenticodeLoadingText, Mode=OneWay}"
                         Signer="{x:Bind ViewModel.Signer, Mode=OneWay}"
                         SigningTime="{x:Bind ViewModel.SigningTime, Mode=OneWay}" />
                 </controls:SettingsCard.Header>


### PR DESCRIPTION
Add loading UI when loading file details. In most cases this will be so fast the user should never see this UI, however on some low end systems I have see this blocking, especially when files are selected on a network share.

<img width="884" height="792" alt="image" src="https://github.com/user-attachments/assets/c440509a-3369-4f29-b9f7-f51fe488cc48" />
