### PR TITLE
Move code-behind string literals to string resource(s)

### DIFF
--- a/src/EM.Hasher.Tests/Services/Hashes/Blake3HashCalculatorTests.cs
+++ b/src/EM.Hasher.Tests/Services/Hashes/Blake3HashCalculatorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using EM.Hasher.Services.Hashes;
+using EM.Hasher.Services.Hashes.Progress;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/EM.Hasher.Tests/Services/Hashes/Crc32HashCalculatorTests.cs
+++ b/src/EM.Hasher.Tests/Services/Hashes/Crc32HashCalculatorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using EM.Hasher.Services.Hashes;
+using EM.Hasher.Services.Hashes.Progress;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/EM.Hasher.Tests/Services/Hashes/Md5HashCalculatorTests.cs
+++ b/src/EM.Hasher.Tests/Services/Hashes/Md5HashCalculatorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using EM.Hasher.Services.Hashes;
+using EM.Hasher.Services.Hashes.Progress;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/EM.Hasher.Tests/Services/Hashes/Sha1HashCalculatorTests.cs
+++ b/src/EM.Hasher.Tests/Services/Hashes/Sha1HashCalculatorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using EM.Hasher.Services.Hashes;
+using EM.Hasher.Services.Hashes.Progress;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/EM.Hasher.Tests/Services/Hashes/Sha256HashCalculatorTests.cs
+++ b/src/EM.Hasher.Tests/Services/Hashes/Sha256HashCalculatorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using EM.Hasher.Services.Hashes;
+using EM.Hasher.Services.Hashes.Progress;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/EM.Hasher.Tests/Services/Hashes/Sha512HashCalculatorTests.cs
+++ b/src/EM.Hasher.Tests/Services/Hashes/Sha512HashCalculatorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using EM.Hasher.Services.Hashes;
+using EM.Hasher.Services.Hashes.Progress;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/EM.Hasher/Controls/IconButton.xaml.cs
+++ b/src/EM.Hasher/Controls/IconButton.xaml.cs
@@ -1,6 +1,6 @@
 /*
  * EM Hasher
- * Copyright © 2025 Enda Mullally (em.apps@outlook.ie)
+ * Copyright © 2025-2026 Enda Mullally (em.apps@outlook.ie)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,6 +35,6 @@ public sealed partial class IconButton : Button
     }
 
     public static readonly DependencyProperty IconProperty =
-        DependencyProperty.Register("Icon", typeof(UIElement), typeof(IconButton), new PropertyMetadata(null));
+        DependencyProperty.Register(nameof(Icon), typeof(UIElement), typeof(IconButton), new PropertyMetadata(null));
 
 }

--- a/src/EM.Hasher/DI/Container.Registry.cs
+++ b/src/EM.Hasher/DI/Container.Registry.cs
@@ -25,6 +25,7 @@ using EM.Hasher.Services.Authenticode;
 using EM.Hasher.Services.Explorer;
 using EM.Hasher.Services.File;
 using EM.Hasher.Services.Hashes;
+using EM.Hasher.Services.Hashes.Progress;
 using EM.Hasher.Services.License;
 using EM.Hasher.Services.Navigation;
 using EM.Hasher.Services.Parsers;

--- a/src/EM.Hasher/Helpers/ResourceExtensions.cs
+++ b/src/EM.Hasher/Helpers/ResourceExtensions.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * EM Hasher
- * Copyright © 2025 Enda Mullally (em.apps@outlook.ie)
+ * Copyright © 2025-2026 Enda Mullally (em.apps@outlook.ie)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,6 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+global using Res = EM.Hasher.Helpers.ResourceExtensions;
+
+using System;
+using System.Diagnostics;
 using Microsoft.Windows.ApplicationModel.Resources;
 
 namespace EM.Hasher.Helpers;
@@ -25,4 +29,23 @@ public static class ResourceExtensions
     private static readonly ResourceLoader _resourceLoader = new();
 
     public static string GetLocalized(this string resourceKey) => _resourceLoader.GetString(resourceKey);
+
+    public static string WithPlaceholder(this string s, string token, string? value)
+    {
+        WarnIfMissing(s, token);
+
+        var key = "{" + token + "}";
+        return s.Contains(key, StringComparison.Ordinal)
+            ? s.Replace(key, value ?? string.Empty)
+            : s;
+    }
+
+    [Conditional("DEBUG")]
+    private static void WarnIfMissing(string s, string key)
+    {
+        if (!s.Contains(key, StringComparison.Ordinal))
+        {
+            Debug.WriteLine($"[Res] Placeholder '{key}' not found in string.");
+        }
+    }
 }

--- a/src/EM.Hasher/Services/FIle/FileDetailsProvider.cs
+++ b/src/EM.Hasher/Services/FIle/FileDetailsProvider.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * EM Hasher
- * Copyright © 2025 Enda Mullally (em.apps@outlook.ie)
+ * Copyright © 2025-2026 Enda Mullally (em.apps@outlook.ie)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,11 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
-using EM.Hasher.Helpers;
 using EM.Hasher.Models;
 using Humanizer;
 
@@ -39,8 +37,8 @@ public class FileDetailsProvider : IFileDetailsProvider
                 var (FileVersion, ProductVersion) = GetFileVersionAndFileProductVersion(fileName);
 
                 var unit = selectedFileInfo.Length == 1
-                    ? ResourceExtensions.GetLocalized("byte")
-                    : ResourceExtensions.GetLocalized("bytes");
+                    ? Res.GetLocalized("byte")
+                    : Res.GetLocalized("bytes");
 
                 return new FileDetailsModel()
                 {
@@ -75,13 +73,13 @@ public class FileDetailsProvider : IFileDetailsProvider
             var fileVersion = versionInfo.FileVersion;
             if (!string.IsNullOrWhiteSpace(fileVersion))
             {
-                fileVersionResult = ResourceExtensions.GetLocalized("File") + ": " + fileVersion;
+                fileVersionResult = Res.GetLocalized("File") + ": " + fileVersion;
             }
 
             var productVersion = versionInfo.ProductVersion;
             if (!string.IsNullOrWhiteSpace(productVersion))
             {
-                productVersionResult = ResourceExtensions.GetLocalized("Product") + ": " + productVersion;
+                productVersionResult = Res.GetLocalized("Product") + ": " + productVersion;
             }
 
             return (fileVersionResult, productVersionResult);

--- a/src/EM.Hasher/Services/Hashes/Blake3HashCalculator.cs
+++ b/src/EM.Hasher/Services/Hashes/Blake3HashCalculator.cs
@@ -19,6 +19,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using EM.Hasher.Services.Hashes.Progress;
 
 namespace EM.Hasher.Services.Hashes;
 

--- a/src/EM.Hasher/Services/Hashes/Crc32HashCalculator.cs
+++ b/src/EM.Hasher/Services/Hashes/Crc32HashCalculator.cs
@@ -19,6 +19,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using EM.Hasher.Services.Hashes.Progress;
 using Force.Crc32;
 
 namespace EM.Hasher.Services.Hashes;

--- a/src/EM.Hasher/Services/Hashes/Md5HashCalculator.cs
+++ b/src/EM.Hasher/Services/Hashes/Md5HashCalculator.cs
@@ -20,6 +20,7 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
+using EM.Hasher.Services.Hashes.Progress;
 
 namespace EM.Hasher.Services.Hashes;
 

--- a/src/EM.Hasher/Services/Hashes/Progress/HashProgressCalculator.cs
+++ b/src/EM.Hasher/Services/Hashes/Progress/HashProgressCalculator.cs
@@ -18,7 +18,7 @@
 
 using System;
 
-namespace EM.Hasher.Services.Hashes;
+namespace EM.Hasher.Services.Hashes.Progress;
 
 public class HashProgressCalculator : IHashProgressCalculator
 {

--- a/src/EM.Hasher/Services/Hashes/Progress/IHashProgressCalculator.cs
+++ b/src/EM.Hasher/Services/Hashes/Progress/IHashProgressCalculator.cs
@@ -18,7 +18,7 @@
 
 using System;
 
-namespace EM.Hasher.Services.Hashes;
+namespace EM.Hasher.Services.Hashes.Progress;
 
 /// <summary>
 /// Calculates the completion percentage of a hash calculation and reports it,

--- a/src/EM.Hasher/Services/Hashes/Sha1HashCalculator.cs
+++ b/src/EM.Hasher/Services/Hashes/Sha1HashCalculator.cs
@@ -20,6 +20,7 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
+using EM.Hasher.Services.Hashes.Progress;
 
 namespace EM.Hasher.Services.Hashes;
 

--- a/src/EM.Hasher/Services/Hashes/Sha256HashCalculator.cs
+++ b/src/EM.Hasher/Services/Hashes/Sha256HashCalculator.cs
@@ -20,6 +20,7 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
+using EM.Hasher.Services.Hashes.Progress;
 
 namespace EM.Hasher.Services.Hashes;
 

--- a/src/EM.Hasher/Services/Hashes/Sha512HashCalculator.cs
+++ b/src/EM.Hasher/Services/Hashes/Sha512HashCalculator.cs
@@ -20,6 +20,7 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
+using EM.Hasher.Services.Hashes.Progress;
 
 namespace EM.Hasher.Services.Hashes;
 

--- a/src/EM.Hasher/Services/Verification/BaseHashVerificationService.cs
+++ b/src/EM.Hasher/Services/Verification/BaseHashVerificationService.cs
@@ -19,6 +19,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using EM.Hasher.Helpers;
 using EM.Hasher.Models;
 
 namespace EM.Hasher.Services.Verification;
@@ -96,7 +97,8 @@ public abstract class BaseHashVerificationService : IHashVerificationService
                         VerificationHashFound = true,
                         IsHashMatching = true,
                         HashVerificationDescription =
-                            $"Verification passed. Matching hash found in '{hashFileName}'"
+                            Res.GetLocalized("VerificationPassed")
+                               .WithPlaceholder("hashFileName", hashFileName)
                     };
                 }
                 else
@@ -106,7 +108,8 @@ public abstract class BaseHashVerificationService : IHashVerificationService
                         VerificationHashFound = true,
                         IsHashMatching = false,
                         HashVerificationDescription =
-                            $"Verification failed! The hash found in '{hashFileName}' does not match."
+                            Res.GetLocalized("VerificationFailed")
+                               .WithPlaceholder("hashFileName", hashFileName)
                     };
                 }
             }

--- a/src/EM.Hasher/Strings/en-us/Resources.resw
+++ b/src/EM.Hasher/Strings/en-us/Resources.resw
@@ -123,8 +123,20 @@
   <data name="bytes" xml:space="preserve">
     <value>bytes</value>
   </data>
+  <data name="CalculatingHash" xml:space="preserve">
+    <value>Calculating {AlgorithmName} hash...</value>
+  </data>
+  <data name="CalculationPending" xml:space="preserve">
+    <value>Calculation pending...</value>
+  </data>
   <data name="File" xml:space="preserve">
     <value>File</value>
+  </data>
+  <data name="HashingAlgorithms" xml:space="preserve">
+    <value>Hashing Algorithms</value>
+  </data>
+  <data name="InvalidDropFile" xml:space="preserve">
+    <value>Please drop a valid file! Special links are not supported.</value>
   </data>
   <data name="LoadingAuthenticodeDetails" xml:space="preserve">
     <value>Loading digital signature details...</value>
@@ -132,11 +144,19 @@
   <data name="LoadingFileDetails" xml:space="preserve">
     <value>Loading file details...</value>
   </data>
+  <data name="OneAtATime" xml:space="preserve">
+    <value>One at a time please :-)</value>
+  </data>
   <data name="Product" xml:space="preserve">
     <value>Product</value>
   </data>
   <data name="SettingsAboutAppDisplayName.Header" xml:space="preserve">
     <value>EM Hasher</value>
-    <comment>`</comment>
+  </data>
+  <data name="VerificationFailed" xml:space="preserve">
+    <value>Verification failed! The hash found in '{hashFileName}' does not match.</value>
+  </data>
+  <data name="VerificationPassed" xml:space="preserve">
+    <value>Verification passed. Matching hash found in '{hashFileName}'</value>
   </data>
 </root>

--- a/src/EM.Hasher/ViewModels/CalculateViewModel.cs
+++ b/src/EM.Hasher/ViewModels/CalculateViewModel.cs
@@ -24,7 +24,6 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
-using EM.Hasher.Helpers;
 using EM.Hasher.Messages;
 using EM.Hasher.Messages.UI;
 using EM.Hasher.Services.Authenticode;
@@ -171,7 +170,7 @@ public partial class CalculateViewModel : ObservableObject, INavigationAware
 
     private async Task LoadFileInfoAsync()
     {
-        SetFileLoadingState(ResourceExtensions.GetLocalized("LoadingFileDetails"));
+        SetFileLoadingState(Res.GetLocalized("LoadingFileDetails"));
 
         var fileDetailsModel = await _fileDetailsProvider.GetFileDetailsAsync(_selectedFileName);
 
@@ -206,7 +205,7 @@ public partial class CalculateViewModel : ObservableObject, INavigationAware
 
     private async Task LoadAuthenticodeInfoAsync()
     {
-        SetAuthenticodeLoadingState(ResourceExtensions.GetLocalized("LoadingAuthenticodeDetails"));
+        SetAuthenticodeLoadingState(Res.GetLocalized("LoadingAuthenticodeDetails"));
 
         var signingInfo = await _authenticodeInfoProvider.GetAuthenticodeInfoAsync(_selectedFileName);
 

--- a/src/EM.Hasher/ViewModels/Controls/FileHashControlViewModel.cs
+++ b/src/EM.Hasher/ViewModels/Controls/FileHashControlViewModel.cs
@@ -21,6 +21,7 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
+using EM.Hasher.Helpers;
 using EM.Hasher.Messages;
 using EM.Hasher.Messages.UI;
 using EM.Hasher.Services.Hashes;
@@ -52,7 +53,7 @@ public partial class FileHashControlViewModel : ObservableObject
 
         WeakReferenceMessenger.Default.Register<QueueAllFileHashRequestMessage>(this, (r, m) =>
         {
-            DisplayText = "Calculation pending...";
+            DisplayText = Res.GetLocalized("CalculationPending");
         });
 
         WeakReferenceMessenger.Default.Register<CalculateAllFileHashRequestMessage>(this, (r, m) =>
@@ -164,7 +165,8 @@ public partial class FileHashControlViewModel : ObservableObject
             _hashValue = string.Empty;
             IsCalculationComplete = false;
 
-            DisplayText = $"Calculating {AlgorithmName} hash...";
+            DisplayText = Res.GetLocalized("CalculatingHash")
+                             .WithPlaceholder("AlgorithmName", AlgorithmName);
 
             ProgressPercentage = 0;
 
@@ -240,6 +242,7 @@ public partial class FileHashControlViewModel : ObservableObject
                 Clipboard.SetContent(hashValuePackage);
 
                 IsTipOpen = true;
+
                 await Task.Delay(2000); // Display for 2 seconds
             }
         }

--- a/src/EM.Hasher/ViewModels/SettingsViewModel.cs
+++ b/src/EM.Hasher/ViewModels/SettingsViewModel.cs
@@ -133,7 +133,7 @@ public partial class SettingsViewModel : ObservableObject
 
         VersionDescription = _appVersion.GetVersionDescription();
 
-        _ = GetTrialLicenseDescriptionAsync();
+        //_ = GetTrialLicenseDescriptionAsync();
 
         _initialized = true;
     }
@@ -144,6 +144,7 @@ public partial class SettingsViewModel : ObservableObject
         get; set;
     }
 
+    /*
     private async Task GetTrialLicenseDescriptionAsync()
     {
         var licenseModel = await _cachedStoreAppLicense.GetCachedStoreAppLicenseAsync();
@@ -163,6 +164,7 @@ public partial class SettingsViewModel : ObservableObject
             TrialLicenseDescription = string.Empty;
         }
     }
+    */
 
     partial void OnIsUppercaseHashValuesChanged(bool value)
     {

--- a/src/EM.Hasher/Views/Calculate.xaml
+++ b/src/EM.Hasher/Views/Calculate.xaml
@@ -91,8 +91,8 @@
                         HorizontalAlignment="Right"
                         VerticalAlignment="Top"
                         Command="{x:Bind ViewModel.OpenFileLocationCommand, Mode=OneWay}"
-                        Visibility="{x:Bind ViewModel.IsLoadingFileInfo, Converter={StaticResource BoolToVisibility}, ConverterParameter=True, Mode=OneWay}"
-                        ToolTipService.ToolTip="Open file location">
+                        ToolTipService.ToolTip="Open file location"
+                        Visibility="{x:Bind ViewModel.IsLoadingFileInfo, Converter={StaticResource BoolToVisibility}, ConverterParameter=True, Mode=OneWay}">
                         <localcontrols:IconButton.Icon>
                             <FontIcon Glyph="&#xE8E5;" />
                             <!--  Open file icon  -->

--- a/src/EM.Hasher/Views/Home.xaml.cs
+++ b/src/EM.Hasher/Views/Home.xaml.cs
@@ -1,6 +1,6 @@
 /*
  * EM Hasher
- * Copyright © 2025 Enda Mullally (em.apps@outlook.ie)
+ * Copyright © 2025-2026 Enda Mullally (em.apps@outlook.ie)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -68,7 +68,7 @@ public sealed partial class Home : Page
                 IsDropGreen = false;
 
                 WeakReferenceMessenger.Default.Send(
-                    new DropFileErrorMessage(true, "One at a time please :-)"));
+                    new DropFileErrorMessage(true, Res.GetLocalized("OneAtATime")));
             }
         }
         finally
@@ -89,7 +89,7 @@ public sealed partial class Home : Page
 
         // Hide default drag visuals
         e.DragUIOverride.IsGlyphVisible = false;
-        e.DragUIOverride.Caption = string.Empty;                     // <-- Clear the caption
+        e.DragUIOverride.Caption = string.Empty;  // <-- Clear the caption
         e.DragUIOverride.IsCaptionVisible = false;
         e.Handled = true;
 
@@ -126,7 +126,7 @@ public sealed partial class Home : Page
                     else
                     {
                         WeakReferenceMessenger.Default.Send(
-                            new DropFileErrorMessage(true, "Please drop a valid file! Special links are not supported."));
+                            new DropFileErrorMessage(true, Res.GetLocalized("InvalidDropFile")));
                     }
                 }
             }

--- a/src/EM.Hasher/Views/SettingsShell.xaml.cs
+++ b/src/EM.Hasher/Views/SettingsShell.xaml.cs
@@ -60,7 +60,7 @@ public sealed partial class SettingsShell : Page
         else if (e.SourcePageType == typeof(HashingAlgorithms))
         {
             UiStateViewModel.IsSettingsSubPageVisible = true;
-            UiStateViewModel.SettingsSubPageTitle = "Hashing Algorithms";
+            UiStateViewModel.SettingsSubPageTitle = Res.GetLocalized("HashingAlgorithms");
         }
     }
 }


### PR DESCRIPTION
Move code-behind string literals to string resource(s) and simplify the string resource helper (less verbose). NOTE: Xaml strings are not included here and will be moved in a future branch and PR.